### PR TITLE
Automatically install networkx and load it if running in docker

### DIFF
--- a/bin/z-wave-graph.py
+++ b/bin/z-wave-graph.py
@@ -7,6 +7,7 @@ import os.path
 import re
 import sys
 import locale
+import site
 locale.setlocale(locale.LC_ALL, '')
 
 # Needed for the docker image:
@@ -22,6 +23,9 @@ def need(what):
     print(".\n")
     sys.exit(1)
 
+# Add persistent site packages if in docker
+if os.path.isdir('/config/deps/lib/python3.6/site-packages'):
+    site.addsitedir('/config/deps/lib/python3.6/site-packages')
 
 try:
     import networkx as nx

--- a/custom_components/z_wave_graph.py
+++ b/custom_components/z_wave_graph.py
@@ -1,0 +1,5 @@
+DOMAIN = 'z_wave_graph'
+REQUIREMENTS = ['networkx']
+
+def setup(hass, config):
+    return True


### PR DESCRIPTION
Installing networkx in an already built docker containers is pretty ugly and would have to be done after every update so I decided to come up with a somewhat cleaner method of installing it.

By adding a dummy component with networkx as a requirement Home Assistant will automatically install it to the persistent site packages (which are part of the config volume and not the container image). My changes to the graphing script then ensures that those are loaded if the folder exists.

Theoretically the custom component should also work when not using docker but that'd require the user to run the script in the same venv as Home Assistant. Is that a reasonable assumption to make?