### PR TITLE
Update automation for new time_pattern platform

### DIFF
--- a/config/automations/z-wave-graph.yaml
+++ b/config/automations/z-wave-graph.yaml
@@ -1,7 +1,6 @@
 - alias: Generate Z-Wave graph
   trigger:
-    platform: time
+    platform: time_pattern
     minutes: '/5'
-    seconds: 00
   action:
     - service: shell_command.z_wave_graph


### PR DESCRIPTION
The automation trigger has been updated to use the new time_pattern
platform that came with Home Assistant 0.86.